### PR TITLE
Add Verilog to supported file types in Info.plist

### DIFF
--- a/src/MacVim/Info.plist
+++ b/src/MacVim/Info.plist
@@ -1200,6 +1200,18 @@
 			<key>CFBundleTypeRole</key>
 			<string>Editor</string>
 		</dict>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>Verilog HDL Source File</string>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>v</string>
+			</array>
+			<key>CFBundleTypeIconFile</key>
+			<string>MacVim-generic</string>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+		</dict>
 
 	</array>
 	<key>CFBundleExecutable</key>
@@ -2630,6 +2642,23 @@
 				<key>public.filename-extension</key>
 				<array>
 					<string>lua</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.plain-text</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Verilog HDL Source File</string>
+			<key>UTTypeIdentifier</key>
+			<string>org.vim.v-file</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>v</string>
 				</array>
 			</dict>
 		</dict>


### PR DESCRIPTION
I added Verilog HDL files to supported file types in Info.plist. Seems to work just fine; I can now quick look files in Finder.